### PR TITLE
Fix wrong syntax usage

### DIFF
--- a/src/lazy-image.directive.js
+++ b/src/lazy-image.directive.js
@@ -11,7 +11,7 @@ angular.module('afkl.lazyImage')
             }]
         };
     })
-    .directive('afklLazyImage', ['$window', '$timeout', 'afklSrcSetService', function ($window, $timeout, srcSetService) {
+    .directive('afklLazyImage', ['$window', '$timeout', 'afklSrcSetService', '$parse', function ($window, $timeout, srcSetService, $parse) {
         'use strict';
 
         // Use srcSetService to find out our best available image
@@ -38,7 +38,7 @@ angular.module('afkl.lazyImage')
                 var timeout;
 
                 var images = attrs.afklLazyImage; // srcset attributes
-                var options = attrs.afklLazyImageOptions ? angular.fromJson(attrs.afklLazyImageOptions) : {}; // options (background, offset)
+                var options = attrs.afklLazyImageOptions ? $parse(attrs.afklLazyImageOptions)(scope) : {}; // options (background, offset)
 
                 var img; // Angular element to image which will be placed
                 var currentImage = null; // current image url


### PR DESCRIPTION
In the current case it's not possible to use valid XHTML if you for example want to use options:
```html
<div afkl-lazy-image-options='{"background": true}'></div>
```
The attribute content should have double quotes and by using ``$parse`` instead of ``angular.fromJson`` it allows more use cases.