### PR TITLE
Update debounce with throttle in service

### DIFF
--- a/src/lazy-image.directive.js
+++ b/src/lazy-image.directive.js
@@ -224,7 +224,7 @@ angular.module('afkl.lazyImage')
 
                 };
 
-                var _onViewChangeDebounced = srcSetService.debounce(_onViewChange, 300);
+                var _onViewChangeThrottled = srcSetService.throttle(_onViewChange, 300);
 
                 // EVENT: RESIZE THROTTLED
                 var _onResize = function () {
@@ -242,11 +242,11 @@ angular.module('afkl.lazyImage')
                     $timeout.cancel(timeout);
 
                     angular.element($window).off('resize', _onResize);
-                    angular.element($window).off('scroll', _onViewChangeDebounced);
+                    angular.element($window).off('scroll', _onViewChangeThrottled);
 
                     if ($container[0] !== $window) {
                         $container.off('resize', _onResize);
-                        $container.off('scroll', _onViewChangeDebounced);
+                        $container.off('scroll', _onViewChangeThrottled);
                     }
 
                     // remove image being placed
@@ -263,12 +263,12 @@ angular.module('afkl.lazyImage')
                 //  - when container size is bigger than window's size
                 //  - when container's side is out of initial window border
                 angular.element($window).on('resize', _onResize);
-                angular.element($window).on('scroll', _onViewChangeDebounced);
+                angular.element($window).on('scroll', _onViewChangeThrottled);
 
                 // if container is not window, set events for container as well
                 if ($container[0] !== $window) {
                     $container.on('resize', _onResize);
-                    $container.on('scroll', _onViewChangeDebounced);
+                    $container.on('scroll', _onViewChangeThrottled);
                 }
 
                 // events for image change

--- a/src/lazy-image.service.js
+++ b/src/lazy-image.service.js
@@ -283,23 +283,21 @@ angular.module('afkl.lazyImage')
 
         };
 
-        // debouncer function to be used in directive
-        function debounce(call, delay) {
-          var preventCalls = false;
+        // throttle function to be used in directive
+        function throttle(callback, delay) {
+            var wait = false;
 
-          return function() {
-            if (!preventCalls) {
-              call();
+            return function () {
+                if (!wait) {
+                    callback.call();
+                    wait = true;
 
-              preventCalls = true;
-
-              $timeout(function() {
-                preventCalls = false;
-              }, delay);
+                    setTimeout(function () {
+                        wait = false;
+                    }, delay);
+                }
             }
-          };
-        }
-
+        };
 
         /**
          * PUBLIC API
@@ -307,7 +305,7 @@ angular.module('afkl.lazyImage')
         return {
             get: getSrcset,        // RETURNS BEST IMAGE AND IMAGE CANDIDATES
             image: getBestImage,   // RETURNS BEST IMAGE WITH GIVEN CANDIDATES
-            debounce: debounce     // RETURNS A DEBOUNCER FUNCTION
+            throttle: throttle     // RETURNS A THROTTLER FUNCTION
         };
 
 

--- a/test/unit/lazyImageSpec.js
+++ b/test/unit/lazyImageSpec.js
@@ -242,30 +242,31 @@ describe("srcset Service:", function() {
         expect(image).toBe(undefined);
     });
 
-    it('Debouncer should be called once in 3 seconds', function() {
-        var stub = jasmine.createSpy('debounced');
-        var debounced = SrcSetService.debounce(stub, 3000);
+    it('Throttler should be called once in 3 seconds', function() {
+        var stub = jasmine.createSpy('throttled');
+        var throttled = SrcSetService.throttle(stub, 3000);
 
         expect(stub).not.toHaveBeenCalled();
 
-        debounced();
-        debounced();
-        debounced();
+        throttled();
+        throttled();
+        throttled();
 
         expect(stub).toHaveBeenCalled();
         expect(stub.calls.count()).toBe(1);
 
         $timeout.flush(1500);
 
-        debounced();
+        throttled();
 
         expect(stub.calls.count()).toBe(1);
 
         $timeout.flush(3500);
 
-        debounced();
+        throttled();
+        throttled();
 
-        expect(stub.calls.count()).toBe(2);
+        expect(stub.calls.count()).toBe(1);
     });
 });
 


### PR DESCRIPTION
Hi folks,

We're using this module in one of our projects. But we've a problem. Actually, our issue is opened [here](https://github.com/afklm/ng-lazy-image/issues/59). When we're scrolling fast, images aren't being loaded. I think it's caused by debounce function. So I've update debounce function with throttle to solve this.